### PR TITLE
Update to embedded-hal 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ...
 
+## [0.5.0] - 2025-04-03
+
+### Changed
+- Updated `embedded-hal` 0.2.5 -> 1.0.0
+- Updated `linux-embedded-hal` 0.3 -> 0.4.0
+- Updated `embedded-hal-mock` 0.7 -> 0.11.1
+
 ## [0.4.0] - 2021-05-22
 
 ### Added
@@ -45,7 +52,8 @@ This is the initial release to crates.io of the feature-complete driver. There
 may be some API changes in the future. All changes will be documented in this
 CHANGELOG.
 
-[Unreleased]: https://github.com/eldruin/pcf857x-rs/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/eldruin/pcf857x-rs/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/eldruin/pcf857x-rs/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/eldruin/pcf857x-rs/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/eldruin/pcf857x-rs/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/eldruin/pcf857x-rs/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-...
-
-## [0.5.0] - 2025-04-03
-
 ### Changed
 - Updated `embedded-hal` 0.2.5 -> 1.0.0
 - Updated `linux-embedded-hal` 0.3 -> 0.4.0
@@ -52,8 +48,7 @@ This is the initial release to crates.io of the feature-complete driver. There
 may be some API changes in the future. All changes will be documented in this
 CHANGELOG.
 
-[Unreleased]: https://github.com/eldruin/pcf857x-rs/compare/v0.5.0...HEAD
-[0.5.0]: https://github.com/eldruin/pcf857x-rs/compare/v0.4.0...v0.5.0
+[Unreleased]: https://github.com/eldruin/pcf857x-rs/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/eldruin/pcf857x-rs/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/eldruin/pcf857x-rs/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/eldruin/pcf857x-rs/compare/v0.1.0...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcf857x"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Diego Barrios Romero <eldruin@gmail.com>"]
 repository = "https://github.com/eldruin/pcf857x-rs"
 license = "MIT OR Apache-2.0"
@@ -21,15 +21,11 @@ include = [
 edition = "2018"
 
 [dependencies]
-embedded-hal = "0.2.5"
+embedded-hal = "1.0.0"
 
 [dev-dependencies]
-linux-embedded-hal = "0.3"
-embedded-hal-mock = "0.7"
+linux-embedded-hal = "0.4.0"
+embedded-hal-mock = "0.11.1"
 
 [profile.release]
 lto = true
-
-[features]
-default = ["unproven"]
-unproven = ["embedded-hal/unproven"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcf857x"
-version = "0.5.0"
+version = "0.4.0"
 authors = ["Diego Barrios Romero <eldruin@gmail.com>"]
 repository = "https://github.com/eldruin/pcf857x-rs"
 license = "MIT OR Apache-2.0"

--- a/src/devices/get_pin.rs
+++ b/src/devices/get_pin.rs
@@ -1,6 +1,6 @@
 use crate::split_pins;
 use crate::{Error, Pcf8574, Pcf8574a, Pcf8575, PinFlag};
-use embedded_hal::blocking::i2c::{Read, Write};
+use embedded_hal::i2c::I2c;
 
 macro_rules! pcf8574_get_pin_impl {
     ( $( $device_name:ident ),+ ) => {
@@ -13,19 +13,20 @@ macro_rules! pcf8574_get_pin_impl {
             // Again, this is only internal so users cannot misuse it.
             impl<I2C, E> split_pins::GetPin<E> for $device_name<I2C>
             where
-                I2C: Read<Error = E> + Write<Error = E>
+                I2C: I2c<Error = E>,
+                E: core::fmt::Debug
             {
                 fn is_pin_high(&self, pin_flag: PinFlag) -> Result<bool, Error<E>> {
-                    self.do_on_acquired(|dev|{
-                    let data = Self::_get(dev, pin_flag)?;
-                    Ok(data & pin_flag.mask as u8 != 0)
+                    self.do_on_acquired(|dev| {
+                        let data = Self::_get(dev, pin_flag)?;
+                        Ok(data & pin_flag.mask as u8 != 0)
                     })
                 }
 
                 fn is_pin_low(&self, pin_flag: PinFlag) -> Result<bool, Error<E>> {
-                    self.do_on_acquired(|dev|{
-                    let data = Self::_get(dev, pin_flag)?;
-                    Ok(data & pin_flag.mask as u8 == 0)
+                    self.do_on_acquired(|dev| {
+                        let data = Self::_get(dev, pin_flag)?;
+                        Ok(data & pin_flag.mask as u8 == 0)
                     })
                 }
             }
@@ -37,7 +38,8 @@ pcf8574_get_pin_impl!(Pcf8574, Pcf8574a);
 
 impl<I2C, E> split_pins::GetPin<E> for Pcf8575<I2C>
 where
-    I2C: Read<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
+    E: core::fmt::Debug
 {
     fn is_pin_high(&self, pin_flag: PinFlag) -> Result<bool, Error<E>> {
         self.do_on_acquired(|dev| {

--- a/src/devices/get_pin.rs
+++ b/src/devices/get_pin.rs
@@ -39,7 +39,7 @@ pcf8574_get_pin_impl!(Pcf8574, Pcf8574a);
 impl<I2C, E> split_pins::GetPin<E> for Pcf8575<I2C>
 where
     I2C: I2c<Error = E>,
-    E: core::fmt::Debug
+    E: core::fmt::Debug,
 {
     fn is_pin_high(&self, pin_flag: PinFlag) -> Result<bool, Error<E>> {
         self.do_on_acquired(|dev| {

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -1,6 +1,5 @@
 pub mod pcf8574;
 pub mod pcf8575;
-mod set_pin;
 
-#[cfg(feature = "unproven")]
 mod get_pin;
+mod set_pin;

--- a/src/devices/pcf8574.rs
+++ b/src/devices/pcf8574.rs
@@ -1,5 +1,5 @@
 use core::cell;
-use embedded_hal::blocking::i2c::{Read, Write};
+use embedded_hal::i2c::I2c;
 
 use crate::split_pins::pcf8574;
 use crate::{Error, PinFlag, SlaveAddr};
@@ -25,7 +25,7 @@ macro_rules! pcf8574 {
 
         impl<I2C, E> $device_name<I2C>
         where
-            I2C: Write<Error = E>,
+            I2C: I2c<Error = E>,
         {
             /// Create new instance of the device
             pub fn new(i2c: I2C, address: SlaveAddr) -> Self {
@@ -91,7 +91,7 @@ macro_rules! pcf8574 {
 
         impl<I2C, E> $device_name<I2C>
         where
-            I2C: Read<Error = E> + Write<Error = E>,
+            I2C: I2c<Error = E>,
         {
             /// Get the status of the selected I/O pins.
             /// The mask of the pins to be read can be created with a combination of

--- a/src/devices/pcf8575.rs
+++ b/src/devices/pcf8575.rs
@@ -1,5 +1,5 @@
 use core::cell;
-use embedded_hal::blocking::i2c::{Read, Write};
+use embedded_hal::i2c::I2c;
 
 use crate::split_pins::pcf8575;
 use crate::{Error, PinFlag, SlaveAddr};
@@ -23,7 +23,7 @@ pub(crate) struct Pcf8575Data<I2C> {
 
 impl<I2C, E> Pcf8575<I2C>
 where
-    I2C: Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     /// Create new instance of the PCF8575 device
     pub fn new(i2c: I2C, address: SlaveAddr) -> Self {
@@ -94,7 +94,7 @@ where
 
 impl<I2C, E> Pcf8575<I2C>
 where
-    I2C: Read<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     /// Get the status of the selected I/O pins.
     /// The mask of the pins to be read can be created with a combination of

--- a/src/devices/set_pin.rs
+++ b/src/devices/set_pin.rs
@@ -1,6 +1,6 @@
 use super::super::split_pins;
 use super::super::{Error, Pcf8574, Pcf8574a, Pcf8575, PinFlag};
-use embedded_hal::blocking::i2c::Write;
+use embedded_hal::i2c::I2c;
 
 macro_rules! pcf8574_set_pin_impl {
     ( $( $device_name:ident ),+ ) => {
@@ -13,7 +13,8 @@ macro_rules! pcf8574_set_pin_impl {
             // Again, this is only internal so users cannot misuse it.
             impl<I2C, E> split_pins::SetPin<E> for $device_name<I2C>
             where
-                I2C: Write<Error = E>
+                I2C: I2c<Error = E>,
+                E: core::fmt::Debug
             {
                 fn set_pin_high(&self, pin_flag: PinFlag) -> Result<(), Error<E>> {
                     self.do_on_acquired(|dev|{
@@ -37,7 +38,8 @@ pcf8574_set_pin_impl!(Pcf8574, Pcf8574a);
 
 impl<I2C, E> split_pins::SetPin<E> for Pcf8575<I2C>
 where
-    I2C: Write<Error = E>,
+    I2C: I2c<Error = E>,
+    E: core::fmt::Debug
 {
     fn set_pin_high(&self, pin_flag: PinFlag) -> Result<(), Error<E>> {
         self.do_on_acquired(|dev| {

--- a/src/devices/set_pin.rs
+++ b/src/devices/set_pin.rs
@@ -39,7 +39,7 @@ pcf8574_set_pin_impl!(Pcf8574, Pcf8574a);
 impl<I2C, E> split_pins::SetPin<E> for Pcf8575<I2C>
 where
     I2C: I2c<Error = E>,
-    E: core::fmt::Debug
+    E: core::fmt::Debug,
 {
     fn set_pin_high(&self, pin_flag: PinFlag) -> Result<(), Error<E>> {
         self.do_on_acquired(|dev| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,9 +134,8 @@
 #![deny(missing_docs)]
 #![no_std]
 
-#[cfg(feature = "unproven")]
-pub use embedded_hal::digital::v2::InputPin;
-pub use embedded_hal::digital::v2::OutputPin;
+pub use embedded_hal::digital::InputPin;
+pub use embedded_hal::digital::OutputPin;
 
 /// All possible errors in this crate
 #[derive(Debug)]
@@ -147,6 +146,12 @@ pub enum Error<E> {
     InvalidInputData,
     /// Could not acquire device. Maybe it is already acquired.
     CouldNotAcquireDevice,
+}
+
+impl<E: core::fmt::Debug> embedded_hal::digital::Error for Error<E> {
+    fn kind(&self) -> embedded_hal::digital::ErrorKind {
+        embedded_hal::digital::ErrorKind::Other
+    }
 }
 
 mod slave_addr;

--- a/src/split_pins.rs
+++ b/src/split_pins.rs
@@ -78,7 +78,7 @@ macro_rules! io_pin_impl {
 
             impl<'a, S, E: core::fmt::Debug> OutputPin for $PX<'a, S, E>
             where S: SetPin<E> {
-                
+
                 fn set_high(&mut self) -> Result<(), Self::Error> {
                     self.0.set_pin_high(PinFlag::$PX)
                 }
@@ -88,10 +88,10 @@ macro_rules! io_pin_impl {
                 }
             }
 
-            
+
             impl<'a, S, E: core::fmt::Debug> InputPin for $PX<'a, S, E>
             where S: GetPin<E> {
-                
+
                 fn is_high(&mut self) -> Result<bool, Self::Error> {
                     self.0.is_pin_high(PinFlag::$PX)
                 }

--- a/tests/pcf8574.rs
+++ b/tests/pcf8574.rs
@@ -136,7 +136,7 @@ macro_rules! pcf8574_pin_test {
     ($px:ident, $value:expr, $default_address:expr) => {
         mod $px {
             use super::*;
-            
+
             use pcf857x::InputPin;
             use pcf857x::OutputPin;
 

--- a/tests/pcf8574.rs
+++ b/tests/pcf8574.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTrans};
+use embedded_hal_mock::eh1::i2c::{Mock as I2cMock, Transaction as I2cTrans};
 use pcf857x::{Error, Pcf8574, Pcf8574a, PinFlag, SlaveAddr};
 mod base;
 
@@ -136,7 +136,7 @@ macro_rules! pcf8574_pin_test {
     ($px:ident, $value:expr, $default_address:expr) => {
         mod $px {
             use super::*;
-            #[cfg(feature = "unproven")]
+            
             use pcf857x::InputPin;
             use pcf857x::OutputPin;
 
@@ -166,7 +166,6 @@ macro_rules! pcf8574_pin_test {
                 expander.destroy().done();
             }
 
-            #[cfg(feature = "unproven")]
             #[test]
             fn can_split_and_get_is_high() {
                 let transactions = [
@@ -175,13 +174,12 @@ macro_rules! pcf8574_pin_test {
                 ];
                 let expander = new(&transactions);
                 {
-                    let parts = expander.split();
+                    let mut parts = expander.split();
                     assert!(parts.$px.is_high().unwrap());
                 }
                 expander.destroy().done();
             }
 
-            #[cfg(feature = "unproven")]
             #[test]
             fn can_split_and_get_is_low() {
                 let transactions = [
@@ -190,7 +188,7 @@ macro_rules! pcf8574_pin_test {
                 ];
                 let expander = new(&transactions);
                 {
-                    let parts = expander.split();
+                    let mut parts = expander.split();
                     assert!(parts.$px.is_low().unwrap());
                 }
                 expander.destroy().done();

--- a/tests/pcf8575.rs
+++ b/tests/pcf8575.rs
@@ -124,7 +124,7 @@ macro_rules! pin_test {
     ($px:ident, $value:expr) => {
         mod $px {
             use super::*;
-            
+
             use pcf857x::InputPin;
             use pcf857x::OutputPin;
 

--- a/tests/pcf8575.rs
+++ b/tests/pcf8575.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTrans};
+use embedded_hal_mock::eh1::i2c::{Mock as I2cMock, Transaction as I2cTrans};
 use pcf857x::{Error, Pcf8575, PinFlag, SlaveAddr};
 mod base;
 
@@ -124,7 +124,7 @@ macro_rules! pin_test {
     ($px:ident, $value:expr) => {
         mod $px {
             use super::*;
-            #[cfg(feature = "unproven")]
+            
             use pcf857x::InputPin;
             use pcf857x::OutputPin;
 
@@ -158,7 +158,6 @@ macro_rules! pin_test {
                 expander.destroy().done();
             }
 
-            #[cfg(feature = "unproven")]
             #[test]
             fn can_split_and_get_is_high() {
                 let transactions = [
@@ -168,13 +167,12 @@ macro_rules! pin_test {
                 let expander = new(&transactions);
 
                 {
-                    let parts = expander.split();
+                    let mut parts = expander.split();
                     assert!(parts.$px.is_high().unwrap());
                 }
                 expander.destroy().done();
             }
 
-            #[cfg(feature = "unproven")]
             #[test]
             fn can_split_and_get_is_low() {
                 let transactions = [
@@ -183,7 +181,7 @@ macro_rules! pin_test {
                 ];
                 let expander = new(&transactions);
                 {
-                    let parts = expander.split();
+                    let mut parts = expander.split();
                     assert!(parts.$px.is_low().unwrap());
                 }
                 expander.destroy().done();


### PR DESCRIPTION
I went ahead and migrated this lib to embedded-hal 1.0.0. I used https://github.com/rust-embedded/embedded-hal/blob/master/docs/migrating-from-0.2-to-1.0.md to guide me through the process.

Let me know if there's something still requiring changes 🙂 